### PR TITLE
sync consent fix

### DIFF
--- a/lib/thirdparty/LBRY.class.php
+++ b/lib/thirdparty/LBRY.class.php
@@ -15,18 +15,18 @@ class LBRY
     public static function getLBCtoUSDRate()
     {
         $response = CurlWithCache::get(static::getApiUrl('/lbc/exchange_rate'), [], [
-      'cache' => 3600, //one hour
-      'json_response' => true
-    ]);
+            'cache' => 3600, //one hour
+            'json_response' => true
+        ]);
         return $response['data']['lbc_usd'] ?? 0;
     }
 
     public static function subscribe($email, $tag = null)
     {
         return Curl::post(static::getApiUrl('/list/subscribe'), array_filter([
-      'email' => $email,
-      'tag' => $tag,
-    ]), ['json_response' => true]);
+            'email' => $email,
+            'tag' => $tag,
+        ]), ['json_response' => true]);
     }
 
     public static function editEmailSettings($token, $email, $isPrimary =null, $isEnabled = null)
@@ -53,17 +53,17 @@ class LBRY
     public static function connectYoutube($channel_name, $immediateSync = false)
     {
         // Uncomment next line for production and comment other return
-        // return Curl::post(static::getApiUrl('/yt/new'), [ 'desired_lbry_channel_name' => $channel_name, 'immediate_sync' => $immediateSync, 'type' => 'sync' ], [ 'json_response' => true ]);
+        return Curl::post(static::getApiUrl('/yt/new'), [ 'desired_lbry_channel_name' => $channel_name, 'immediate_sync' => $immediateSync, 'type' => 'sync' ], [ 'json_response' => true ]);
 
         // Uncomment next line for development and comment other return (this also requires the testnet API)
-        return Curl::post(static::getApiUrl('/yt/new'), [
-            'desired_lbry_channel_name' => $channel_name,
-            'immediate_sync' => $immediateSync,
-            'return_url' => 'http://localhost:8000/youtube/status/',
-            'type' => 'sync'
-        ], [
-            'json_response' => true
-        ]);
+        // return Curl::post(static::getApiUrl('/yt/new'), [
+        //     'desired_lbry_channel_name' => $channel_name,
+        //     'immediate_sync' => $immediateSync,
+        //     'return_url' => 'http://localhost:8000/youtube/status/',
+        //     'type' => 'sync'
+        // ], [
+        //     'json_response' => true
+        // ]);
     }
 
     // Check the sync status
@@ -82,23 +82,19 @@ class LBRY
         $postParams = array('status_token' => $status_token);
 
         if ($email) {
-            array_push($postParams, array('new_email' => $email));
+            $postParams['new_email'] = $email;
         }
 
         if ($sync_consent) {
-          array_push($postParams, array('sync_consent' => $sync_consent));
+            if ($sync_consent === 0) {
+                $sync_consent = null;
+            }
+
+            $postParams['sync_consent'] = $sync_consent;
         }
 
-        // if ($sync_consent !== null) {
-        //     if ($sync_consent === 0) {
-        //         $sync_consent = null;
-        //     }
-
-        //     array_push($postParams, ['sync_consent' => $sync_consent]);
-        // }
-
         if ($new_preferred_channel) {
-            array_push($postParams, array('new_preferred_channel' => $channel_name));
+            $postParams['new_preferred_channel'] = $channel_name;
         }
 
         return Curl::post(static::getApiUrl("/yt/update"), $postParams, ['json_response' => true]);

--- a/lib/thirdparty/LBRY.class.php
+++ b/lib/thirdparty/LBRY.class.php
@@ -15,19 +15,18 @@ class LBRY
     public static function getLBCtoUSDRate()
     {
         $response = CurlWithCache::get(static::getApiUrl('/lbc/exchange_rate'), [], [
-          'cache' => 3600, //one hour
-          'json_response' => true
-        ]);
-
+      'cache' => 3600, //one hour
+      'json_response' => true
+    ]);
         return $response['data']['lbc_usd'] ?? 0;
     }
 
     public static function subscribe($email, $tag = null)
     {
         return Curl::post(static::getApiUrl('/list/subscribe'), array_filter([
-          'email' => $email,
-          'tag' => $tag,
-        ]), ['json_response' => true]);
+      'email' => $email,
+      'tag' => $tag,
+    ]), ['json_response' => true]);
     }
 
     public static function editEmailSettings($token, $email, $isPrimary =null, $isEnabled = null)
@@ -54,23 +53,17 @@ class LBRY
     public static function connectYoutube($channel_name, $immediateSync = false)
     {
         // Uncomment next line for production and comment other return
+        // return Curl::post(static::getApiUrl('/yt/new'), [ 'desired_lbry_channel_name' => $channel_name, 'immediate_sync' => $immediateSync, 'type' => 'sync' ], [ 'json_response' => true ]);
+
+        // Uncomment next line for development and comment other return (this also requires the testnet API)
         return Curl::post(static::getApiUrl('/yt/new'), [
             'desired_lbry_channel_name' => $channel_name,
             'immediate_sync' => $immediateSync,
+            'return_url' => 'http://localhost:8000/youtube/status/',
             'type' => 'sync'
         ], [
             'json_response' => true
         ]);
-
-        // Uncomment next line for development and comment other return (this also requires the testnet API)
-        // return Curl::post(static::getApiUrl('/yt/new'), [
-        //     'desired_lbry_channel_name' => $channel_name,
-        //     'immediate_sync' => $immediateSync,
-        //     'return_url' => 'http://localhost:8000/youtube/status/',
-        //     'type' => 'sync'
-        // ], [
-        //     'json_response' => true
-        // ]);
     }
 
     // Check the sync status
@@ -86,20 +79,29 @@ class LBRY
 
     public static function editYouTube($status_token, $channel_name, $email, $sync_consent)
     {
-        if ($email == null) {
-            return Curl::post(static::getApiUrl("/yt/update"), [
-                'new_preferred_channel' => $channel_name,
-                'status_token' => $status_token,
-                'sync_consent' => $sync_consent
-            ], ['json_response' => true]);
-        } else {
-            return Curl::post(static::getApiUrl("/yt/update"), [
-                'new_email' => $email,
-                'new_preferred_channel' => $channel_name,
-                'status_token' => $status_token,
-                'sync_consent' => $sync_consent
-            ], ['json_response' => true]);
+        $postParams = array('status_token' => $status_token);
+
+        if ($email) {
+            array_push($postParams, array('new_email' => $email));
         }
+
+        if ($sync_consent) {
+          array_push($postParams, array('sync_consent' => $sync_consent));
+        }
+
+        // if ($sync_consent !== null) {
+        //     if ($sync_consent === 0) {
+        //         $sync_consent = null;
+        //     }
+
+        //     array_push($postParams, ['sync_consent' => $sync_consent]);
+        // }
+
+        if ($new_preferred_channel) {
+            array_push($postParams, array('new_preferred_channel' => $channel_name));
+        }
+
+        return Curl::post(static::getApiUrl("/yt/update"), $postParams, ['json_response' => true]);
     }
 
     public static function logWebVisitor($site, $visitorID, $IPAddress)

--- a/view/template/acquisition/youtube.php
+++ b/view/template/acquisition/youtube.php
@@ -36,6 +36,7 @@
 
     <div class="inner-wrap inner-wrap--center-left">
       <h1 class="weight-light">LBRY &times; YouTube Sync</h1>
+      <?php echo sys_get_temp_dir() ?>
       <h2 class="weight-light">Get your YouTube videos in front of the LBRY audience</h2>
       <button class="button button--inverse" data-id="scroll-to-claim" type="button">Claim your channel now</button>
     </div>

--- a/view/template/acquisition/youtube.php
+++ b/view/template/acquisition/youtube.php
@@ -36,7 +36,6 @@
 
     <div class="inner-wrap inner-wrap--center-left">
       <h1 class="weight-light">LBRY &times; YouTube Sync</h1>
-      <?php echo sys_get_temp_dir() ?>
       <h2 class="weight-light">Get your YouTube videos in front of the LBRY audience</h2>
       <button class="button button--inverse" data-id="scroll-to-claim" type="button">Claim your channel now</button>
     </div>


### PR DESCRIPTION
These changes *should* eliminate the issue with internal APIs where `null` is sent instead of `0`.