### PR TITLE
Ignore timeout curl exceptions

### DIFF
--- a/lib/tools/Curl.class.php
+++ b/lib/tools/Curl.class.php
@@ -144,7 +144,10 @@ class Curl
                 $options['retry'] -= 1;
                 return static::doCurl($method, $url, $params, $options);
             }
-            throw new CurlException($ch);
+            // Ignore the timeout exceptions
+            if (!in_array(curl_errno($ch), array(CURLE_OPERATION_TIMEDOUT, CURLE_OPERATION_TIMEOUTED))) {
+                throw new CurlException($ch);
+            }
         }
 
         curl_close($ch);


### PR DESCRIPTION
### Description

Throw Curl exceptions Unless if they are timeout related.

As far as I can see all exceptions generated are being forwarded to slack thus I ignored these specific exceptions from Curl.class.php

Another solution would be to change the hardcoded  5 seconds timeout limit on curl.class.php.
_This bit of functionality is **hard to test from my side** with no slack access, but it should filter properly those exceptions on curl._ 
### Fixes ##1023 