### PR TITLE
Change /faq/claimtrie-implementation to a link

### DIFF
--- a/content/faq/naming.md
+++ b/content/faq/naming.md
@@ -54,7 +54,7 @@ LBRY supports several types of URL resolution:
 
 4. **Names are more like search terms.** When a user searches the LBRY network, or a recommendation engine suggests content, all valid claims are considered. Not having the community URL for your content does not mean no one will see it. Many different pieces of content under the same name can be displayed when users look for content on the network.
 
-For more details on claims, please see /faq/claimtrie-implementation
+For more details on claims, please see [lbry.com/faq/claimtrie-implementation](/faq/claimtrie-implementation)
 
 ### Experimentation
 


### PR DESCRIPTION
Changing this URL to a link allows users to click it instead of having to edit the URL in their browser, which may cause some confusion. The target location (lbry.com/faq/claimtrie-implementation) is still shown as plain text, so the user knows where they are being redirected to.