### PR TITLE
Removed homepage exception for twitter image (fix for twitter image n…

### DIFF
--- a/view/template/layout/basic.php
+++ b/view/template/layout/basic.php
@@ -63,7 +63,7 @@
         <meta name="twitter:image" content="<?php echo $url ?>" />
     <?php endif ?>
 
-    <?php if (in_array($_SERVER['REQUEST_URI'], ['/', '/android', '/get'])): ?>
+    <?php if (in_array($_SERVER['REQUEST_URI'], ['/android', '/get'])): ?>
       <meta name="twitter:card" content="app"/>
       <meta name="twitter:app:country" content="US"/>
       <meta name="twitter:app:name:googleplay" content="LBRY beta"/>

--- a/view/template/layout/basic.php
+++ b/view/template/layout/basic.php
@@ -63,7 +63,7 @@
         <meta name="twitter:image" content="<?php echo $url ?>" />
     <?php endif ?>
 
-    <?php if (in_array($_SERVER['REQUEST_URI'], ['/android', '/get'])): ?>
+    <?php if (in_array($_SERVER['REQUEST_URI'], ['/android'])): ?>
       <meta name="twitter:card" content="app"/>
       <meta name="twitter:app:country" content="US"/>
       <meta name="twitter:app:name:googleplay" content="LBRY beta"/>


### PR DESCRIPTION
…ot showing)

### Description

Removed a homepage exception that was stopping from the Twitter image to not show on homepage (lbry.com). Image was not showing on homepage (lbry.com) but shows on other URL (lbry.com?test=123). It was because "content" attribute for a "twitter:card" meta was being set to "app" for homepage which was causing the image to not show for the home url. Submitted in response to: https://twitter.com/jeremykauffman/status/1174725053877039104
Solution was proposed in my tweet: https://twitter.com/adnan360/status/1176393294030364672

### Fixes #
Fixes #1110 Fix for Twitter card image not showing for homepage