### PR TITLE
Fix claimId not being passed to report form.

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -123,7 +123,7 @@ class Controller
         $router->get('/list/unsubscribe/{email}', 'MailActions::executeUnsubscribe');
         $router->any('/list/edit/{token}', 'MailActions::editEmailSettings');
 
-        $router->any('/dmca', 'ReportActions::executeDmca');
+        $router->any('/dmca/{claimid}', 'ReportActions::executeDmcaWithClaimId');
 
         $router->post('/youtube/edit', 'AcquisitionActions::executeYoutubeEdit');
         $router->post('/youtube/token', 'AcquisitionActions::executeYoutubeToken');

--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -123,6 +123,7 @@ class Controller
         $router->get('/list/unsubscribe/{email}', 'MailActions::executeUnsubscribe');
         $router->any('/list/edit/{token}', 'MailActions::editEmailSettings');
 
+        $router->any('/dmca', 'ReportActions::executeDmca');
         $router->any('/dmca/{claimid}', 'ReportActions::executeDmcaWithClaimId');
 
         $router->post('/youtube/edit', 'AcquisitionActions::executeYoutubeEdit');

--- a/controller/action/ReportActions.class.php
+++ b/controller/action/ReportActions.class.php
@@ -2,11 +2,16 @@
 
 class ReportActions extends Actions
 {
-    public static function executeDmca()
+    public static function executeDmcaWithClaimId(string $claimId)
     {
+
+        if (isset($claimId)) {
+            $claimId = htmlspecialchars($claimId);
+        }
+
         Response::setHeader(Response::HEADER_CROSS_ORIGIN, "*");
         if (!Request::isPost()) {
-            return ['report/dmca'];
+            return ['report/dmca', ['claimId' => $claimId]];
         }
 
         $values = [];
@@ -24,10 +29,6 @@ class ReportActions extends Actions
             $values[$field] = $value;
         }
 
-        if ($_GET['claim_id'] && !$values['identifier']) {
-            $values['identifier'] = htmlspecialchars($_GET['claim_id']);
-        }
-
         if (!$errors) {
             $values['report_id'] = Encoding::base58Encode(random_bytes(6));
             Mailgun::sendDmcaReport($values);
@@ -37,7 +38,8 @@ class ReportActions extends Actions
 
         return ['report/dmca', [
             'errors' => $errors,
-            'values' => $values
+            'values' => $values,
+            'claimId' => $claimId
         ]];
     }
 }

--- a/controller/action/ReportActions.class.php
+++ b/controller/action/ReportActions.class.php
@@ -3,34 +3,22 @@
 class ReportActions extends Actions
 {
 
-    /* TODO: Investigate optional route parameters, maybe nullable type hints from php 7.1 help with that. */
+    /**
+     * Handles all routing requests without a claimId as parameter.
+     * E.g. /dmca
+     *
+     * @return array
+     * @throws Exception
+     */
     public static function executeDmca() {
-        Response::setHeader(Response::HEADER_CROSS_ORIGIN, "*");
-        if (!Request::isPost()) {
-            return ['report/dmca'];
-        }
+
+        self::setResponseHeader();
+        self::redirectIfPostRequest(false, '');
 
         $values = [];
         $errors = [];
 
-        foreach (['name', 'email', 'rightsholder', 'identifier'] as $field) {
-            $value = Request::getPostParam($field);
-
-            if (!$value) {
-                $errors[$field] = __('form_error.required');
-            } elseif ($field == 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
-                $errors[$field] = __('form_error.invalid');
-            }
-
-            $values[$field] = $value;
-        }
-
-        if (!$errors) {
-            $values['report_id'] = Encoding::base58Encode(random_bytes(6));
-            Mailgun::sendDmcaReport($values);
-            Session::setFlash('success', '<h3>Report Submitted</h3><p>We will respond shortly.</p><p>This ID for this report is <strong>' . $values['report_id'] . '</strong>. Please reference this ID when contacting us regarding this report.</p>');
-            return Controller::redirect(Request::getRelativeUri(), 303);
-        }
+        self::validateForm($values, $errors);
 
         return ['report/dmca', [
             'errors' => $errors,
@@ -38,27 +26,50 @@ class ReportActions extends Actions
         ]];
     }
 
-    public static function executeDmcaWithClaimId(string $claimId)
-    {
+    /**
+     * Handles all routing requests with a claimId as routing parameter since the used router doesn't support optional parameters.
+     * E.g. /dmca/this-is-a-claim-id
+     *
+     * @param string $claimId
+     *
+     * @return array
+     * @throws Exception
+     */
+    public static function executeDmcaWithClaimId(string $claimId): array {
 
-        if (isset($claimId)) {
-            $claimId = htmlspecialchars($claimId);
-        }
+        $claimId = htmlspecialchars($claimId);
 
-        Response::setHeader(Response::HEADER_CROSS_ORIGIN, "*");
-        if (!Request::isPost()) {
-            return ['report/dmca', ['claimId' => $claimId]];
-        }
+        self::setResponseHeader();
+        self::redirectIfPostRequest(true, $claimId);
 
         $values = [];
         $errors = [];
+
+        self::validateForm($values, $errors);
+
+        return ['report/dmca', [
+            'errors' => $errors,
+            'values' => $values,
+            'claimId' => $claimId
+        ]];
+    }
+
+    /**
+     * @param array $values
+     * @param array $errors
+     *
+     * @return array
+     * @throws Exception
+     */
+    private static function validateForm(array $values, array $errors)
+    {
 
         foreach (['name', 'email', 'rightsholder', 'identifier'] as $field) {
             $value = Request::getPostParam($field);
 
             if (!$value) {
                 $errors[$field] = __('form_error.required');
-            } elseif ($field == 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            } elseif ($field === 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
                 $errors[$field] = __('form_error.invalid');
             }
 
@@ -72,10 +83,34 @@ class ReportActions extends Actions
             return Controller::redirect(Request::getRelativeUri(), 303);
         }
 
-        return ['report/dmca', [
-            'errors' => $errors,
-            'values' => $values,
-            'claimId' => $claimId
-        ]];
+    }
+
+    /**
+     * Sets the response header.
+     */
+    private static function setResponseHeader()
+    {
+        Response::setHeader(Response::HEADER_CROSS_ORIGIN, "*");
+    }
+
+    /**
+     * Chooses the right template according to passed variables.
+     *
+     * @param bool   $hasClaimId
+     * @param string $claimId
+     *
+     * @return array
+     */
+    private static function redirectIfPostRequest(bool $hasClaimId = false, string $claimId = '') {
+
+        if ($hasClaimId && !empty($claimId)) {
+            $returnValue = ['report/dmca', ['claimId' => $claimId]];
+        } else {
+            $returnValue = ['report/dmca'];
+        }
+
+        if (!Request::isPost()) {
+            return $returnValue;
+        }
     }
 }

--- a/controller/action/ReportActions.class.php
+++ b/controller/action/ReportActions.class.php
@@ -2,6 +2,42 @@
 
 class ReportActions extends Actions
 {
+
+    /* TODO: Investigate optional route parameters, maybe nullable type hints from php 7.1 help with that. */
+    public static function executeDmca() {
+        Response::setHeader(Response::HEADER_CROSS_ORIGIN, "*");
+        if (!Request::isPost()) {
+            return ['report/dmca'];
+        }
+
+        $values = [];
+        $errors = [];
+
+        foreach (['name', 'email', 'rightsholder', 'identifier'] as $field) {
+            $value = Request::getPostParam($field);
+
+            if (!$value) {
+                $errors[$field] = __('form_error.required');
+            } elseif ($field == 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                $errors[$field] = __('form_error.invalid');
+            }
+
+            $values[$field] = $value;
+        }
+
+        if (!$errors) {
+            $values['report_id'] = Encoding::base58Encode(random_bytes(6));
+            Mailgun::sendDmcaReport($values);
+            Session::setFlash('success', '<h3>Report Submitted</h3><p>We will respond shortly.</p><p>This ID for this report is <strong>' . $values['report_id'] . '</strong>. Please reference this ID when contacting us regarding this report.</p>');
+            return Controller::redirect(Request::getRelativeUri(), 303);
+        }
+
+        return ['report/dmca', [
+            'errors' => $errors,
+            'values' => $values
+        ]];
+    }
+
     public static function executeDmcaWithClaimId(string $claimId)
     {
 

--- a/view/template/report/dmca.php
+++ b/view/template/report/dmca.php
@@ -42,7 +42,7 @@
 
         <?php echo View::render('form/_formRow', [
           'field'    => 'identifier',
-          'value'    => $values['identifier'] ?? null,
+          'value'    => $claimId ?? null,
           'error'    => $errors['identifier'] ?? null,
           'label'    => __('dmca.form_labels.identifier'),
           'help'     => __('dmca.form_help.identifier'),


### PR DESCRIPTION
Fixes issue #582.

### Description

Used the Router to solve this problem a little more elegantly than just using an GET parameter in url.
Needed to slightly change Routing, ReportActions and the dmca page.

New route for dmca would be: 

/dmca/this-is-a-claim-id

### Fixes

Fixes #582
Closes #582