### PR TITLE
fix word cut off issue in nav

### DIFF
--- a/web/scss/components/_header.scss
+++ b/web/scss/components/_header.scss
@@ -303,6 +303,7 @@ drawer-section {
 }
 
 drawer-title {
+  word-wrap: normal;
   @media (max-width: 950px) {
     font-size: 1.25rem;
     font-weight: 200;


### PR DESCRIPTION
### Description
Fixes issue #1131 Firefox issue where word breaks in nav. 

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #