### PR TITLE
hacky app image support

### DIFF
--- a/lib/tools/OS.class.php
+++ b/lib/tools/OS.class.php
@@ -83,6 +83,7 @@ class OS
     {
         switch ($ext) {
       case 'deb':
+      case 'AppImage':
         return OS::OS_LINUX;
 
       case 'dmg':

--- a/view/template/download/_downloadButton.php
+++ b/view/template/download/_downloadButton.php
@@ -1,15 +1,24 @@
-<?php if ($downloadUrl): ?>
+<?php if ($skipRender): ?>
+<?php elseif ($downloadUrl): ?>
   <?php if ($os !== OS::OS_ANDROID): ?>
-    <a class="button button--<?php echo $buttonStyle?>"
-      download
-      href="<?php echo $downloadUrl ?>"
-      id="get-download-btn"
-      data-facebook-track="1"
-      data-analytics-category="Sign Up"
-      data-analytics-action="Download"
-      data-analytics-label="<?php echo $analyticsLabel ?>"
-      title="Download our app"
-    ><?php echo __('download.for-os2', ['%os%' => OS::OS_DETAIL($os)[1]]) ?></a>
+    <?php if ($isDownload): ?>
+      <a class="button button--<?php echo $buttonStyle?>"
+        download
+        href="<?php echo $downloadUrl ?>"
+        id="get-download-btn"
+        data-facebook-track="1"
+        data-analytics-category="Sign Up"
+        data-analytics-action="Download"
+        data-analytics-label="<?php echo $analyticsLabel ?>"
+        title="Download LBRY App"
+      ><?php echo $buttonLabel ?></a>
+    <?php else: ?>
+      <a class="button button--<?php echo $buttonStyle?>"
+         href="<?php echo $downloadUrl ?>"
+         id="get-download-btn"
+         title="Download LBRY App"
+      ><?php echo $buttonLabel ?></a>
+    <?php endif ?>
   <?php else: ?>
     <a
       class="button button--google-play"

--- a/view/template/download/_meta.php
+++ b/view/template/download/_meta.php
@@ -4,7 +4,7 @@
   <br/>
 
   <?php if ($os === OS::OS_LINUX): ?>
-    Works with Ubuntu, Debian, or any distro with <code>apt</code> or <code>dpkg</code>. For other Linux flavors including Arch and Flatpak support or compiling from source, <a href="https://github.com/lbryio/lbry-desktop#install">see our GitHub install page</a>.
+    We provide app builds as AppImage and .deb. For other Linux flavors including Arch and Flatpak support or compiling from source, <a href="https://github.com/lbryio/lbry-desktop#install">see our GitHub install page</a>.
   <?php elseif ($os === OS::OS_OSX): ?>
     Works with with macOS version 10.12.4 (Sierra), and higher.
   <?php elseif ($sourceLink): ?>

--- a/view/template/download/get.php
+++ b/view/template/download/get.php
@@ -19,8 +19,15 @@
           <p>Securely download the LBRY app here, and see what all the fuss is about!</p>
           <?php $metaHtml = $os !== OS::OS_ANDROID ? View::Render('download/_meta') : false ?>
           <?php echo View::Render('download/_downloadButton', [
-            'buttonStyle' => 'primary'
+            'buttonStyle' => 'primary',
+            'preferredExt' => $preferredExt
           ])?>
+        <?php if ($os === OS::OS_LINUX && $preferredExt === 'AppImage'): ?>
+          <?php echo View::Render('download/_downloadButton', [
+            'buttonStyle' => 'primary',
+            'preferredExt' => 'deb'
+          ])?>
+        <?php endif ?>
 
           <?php if ($os === OS::OS_ANDROID): ?>
             <p style="font-size: 0.8rem;">You can also <a href="http://lbry.com/releases/lbry-android.apk" title="Download our Android app directly">download</a> our Android app directly</p>


### PR DESCRIPTION
this:

- makes all "download for linux" buttons link to /linux rather than specific files unless `preferredExt` is passed specifically
- makes /linux show buttons for appimage and deb, if they exist
- makes `/release/<repo>.ext` URLs work if repo has multiple release types for an OS

It is done in a semi-hacky way. If we ever needed to add a third Linux release type, it'd be easy, but if we ever needed to support multiple build artificats on another OS, it should be more fundamentally overhauled.