### PR TITLE
Update exchanges.md

### DIFF
--- a/content/faq/exchanges.md
+++ b/content/faq/exchanges.md
@@ -10,7 +10,6 @@ We are listed on several exchanges. You can buy or sell LBRY Credits at one of t
 - [CoinEx BTC](https://www.coinex.com/exchange?currency=btc&dest=lbc) / [USDT](https://www.coinex.com/exchange?currency=usdt&dest=lbc)
 - [Upbit](https://upbit.com/exchange?code=CRIX.UPBIT.BTC-LBC)
 - [VCC](https://vcc.exchange/exchange/basic?currency=btc&coin=lbc)
-- [BigONE](https://big.one/trade/LBC-BTC)
 - [Coinspot](https://www.coinspot.com.au/buy/lbc)
 - [Coindeal](https://frontend.coindeal.com/market/trade.html?pair=LBC/BTC)
 


### PR DESCRIPTION
# Description
Looks like big.one dropped LBC.  If not, the current link on this page is broken, goes to a 404 page.
Removed hyperlink to https://big.one

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #