### PR TITLE
dmca.md - fix typo and sentence structure.

### DIFF
--- a/content/faq/dmca.md
+++ b/content/faq/dmca.md
@@ -17,9 +17,9 @@ Open the LBRY and navigate to the content you wish to report. Underneath the con
 
 ## How does LBRY handle and respond to a DMCA request or takedown notice?
 
-Upon receipt of a DMCA request from the content owner or legal representative, LBRY Inc. will try its best to validate the legitimary of the request and notify the alleged infringing party about it if there's a potential for dispute. Once validated, we will block access to content in any LBRY Inc. owned applications upon receipt of a DMCA takedown notice. The opposite party can file a DMCA counter notice if they believe they have a right to publish the content. If you have questions about the DMCA process, you can [find more information here.](https://www.dmca.com/faq/What-is-a-DMCA-Takedown)
+Upon receipt of a DMCA request from the content owner or legal representative, LBRY Inc. will try its best to validate the legitimacy of the request and notify the alleged infringing party about it if there's a potential for dispute. Once validated, we will block access to content in any LBRY Inc. owned applications upon receipt of a DMCA takedown notice. The opposite party can file a DMCA counter notice if they believe they have a right to publish the content. If you have questions about the DMCA process, you can [find more information here.](https://www.dmca.com/faq/What-is-a-DMCA-Takedown)
 
-LBRY Inc. will also remove any data related to the infringing content from servers within its control. LBRY also must abide by the [red flag rule](https://en.wikipedia.org/wiki/Online_Copyright_Infringement_Liability_Limitation_Act#Red_flags) also. 
+LBRY Inc. will also remove any data related to the infringing content from servers within its control. LBRY will also abide by the [red flag rule](https://en.wikipedia.org/wiki/Online_Copyright_Infringement_Liability_Limitation_Act#Red_flags). 
 
 Due to the immutable nature of the LBRY blockchain, a record and metadata of the infringing content may continue to exist on network hosts if the original publisher does not remove it. The data may still exist on the original publisher's computer (and anyone who may have downloaded it prior to it being blocked) but will not be accessible through any LBRY Inc. controlled applications.
 


### PR DESCRIPTION
### Description
1. I don't think `legitimary` exists in the dictionary, so I changed to `legitimacy`. But I could be wrong.
2. Fixed multiple `also` in a particular sentence.

### Fixes #
N/A