### PR TITLE
Change old video style that didn't work or play

### DIFF
--- a/view/template/page/home.php
+++ b/view/template/page/home.php
@@ -36,7 +36,7 @@
   <section class="home__hype">
     <div class="inner-wrap">
       <p>See previews of the LBRY app and the great content available now on LBRY.</p>
-      <?php echo View::render('download/_videoIntro') ?>
+      <iframe width="560" height="315" src="https://lbry.tv/$/embed/meetlbrytv/c6c0a5caa6cc391696e1270e33cd9d24ee7c2d52" allowfullscreen></iframe>
     </div>
   </section>
 


### PR DESCRIPTION
I added an embed as that is a thing now. Previously, every time I looked at the website the video wouldn't play on any device without downloading the video and trying to edit the code in inspect element.

### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #