### PR TITLE
Community servers for Hardware wallets

### DIFF
--- a/content/faq/multisig.md
+++ b/content/faq/multisig.md
@@ -56,3 +56,8 @@ LBRY Vault wallet files and blockchain data can be found in the App Data Roaming
 If the balance is not updating properly or transaction not showing confirmed, try restarting the application. To resync the wallet data, delete the blockchain_headers file in `%appdata%\Electrum-lbry` and restart the application.
 
 If you are having trouble sending due to fees, make sure that fee estimation is set to static, and edit fees manually is checked under **Tools > Preferences**.
+
+If you have problems connecting to LBRY servers try adding one of community hosted server by going to **Tools > Network > Server**
+| Adress   |      Region      |  Host |
+|----------|:-------------:|------:|
+| spv1.allaboutlbc.com:50001 |  EU | Madiator2011 |


### PR DESCRIPTION
Added Community servers in Troubleshooting section so users wont be off when LBRY SPV1 have problems and they can pick up one of the community server instead.