### PR TITLE
Fix one letter typo in view-rewards.md

### DIFF
--- a/content/faq/view-rewards.md
+++ b/content/faq/view-rewards.md
@@ -43,7 +43,7 @@ Typical disqualifications include:
 
 ## I'm eligible but not receiving tips, what can I do?
 
-We will monitor for new channels to opt in automatically, but most likely you will need to reach out to us if you quality. Please read the requirements carefully before contacting us. To reach out, [send us an email](mailto:hello@lbry.com) and tell us more about your channel and content. This will later be made clearer in the app and automated via an opt in process.
+We will monitor for new channels to opt in automatically, but most likely you will need to reach out to us if you qualify. Please read the requirements carefully before contacting us. To reach out, [send us an email](mailto:hello@lbry.com) and tell us more about your channel and content. This will later be made clearer in the app and automated via an opt in process.
 
 ## I'm in need of some assistance, can you help?
 


### PR DESCRIPTION
In the second to last paragraph, first sentence the end read "...reach out to us if you quality." I suggest changing this to "...reach out to us if you qualify."

### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #