### PR TITLE
Update exchanges.md

### DIFF
--- a/content/faq/exchanges.md
+++ b/content/faq/exchanges.md
@@ -19,9 +19,6 @@ For a guide on buying/selling, see our [Bittrex purchasing/selling FAQ](/faq/buy
 - [Coindeal](https://frontend.coindeal.com/market/trade.html?pair=LBC/BTC)
 
 ## Instant exchanges
-- [Simple Swap](https://simpleswap.io)
-- [Stealthex](https://stealthex.io/)
-- [SwapSpace](https://swapspace.co)
 - [Swapzone](https://swapzone.io)
 
 ## Decentralized exchanges (DEX)


### PR DESCRIPTION
The 3 of the 4 instant exchanges don't list LBC at all. Swapzone has it listed but offers are hard to find.

### Description

3 of the 4 instant exchanges on the page don't even have LBC listed anymore. 

### Fixes #

Removed listings to instant exchanges that are out of date.