### PR TITLE
Remove extra backslash

### DIFF
--- a/content/faq/earn-income.md
+++ b/content/faq/earn-income.md
@@ -14,6 +14,6 @@ With LBRY, pricing is completely at the discretion of the creator, and 100% of t
 
 Because LBRY uses digital currency (a la Bitcoin), creators can accept micropayments for every view without worrying about credit card processing fees. Or a studio could use LBRY to distribute a theatrical release to independent theaters and charge thousands of dollars per download. The only constraint on pricing is what your viewers are willing to pay.
 
-With YouTube monetization, creators earn a variable amount based on viewers' engagement with ads. There is no set formula, but we've found a reasonable guesstimate of around [\$2 per thousand views](https://www.quora.com/How-much-does-YouTube-pay-partners-for-their-content). This works out to a penny per 5 views. So on LBRY, if you charge just one penny per view (a price any viewer would pay without a second thought), you may get 5X the per-view earnings you'd get from YouTube instantly!
+With YouTube monetization, creators earn a variable amount based on viewers' engagement with ads. There is no set formula, but we've found a reasonable guesstimate of around [$2 per thousand views](https://www.quora.com/How-much-does-YouTube-pay-partners-for-their-content). This works out to a penny per 5 views. So on LBRY, if you charge just one penny per view (a price any viewer would pay without a second thought), you may get 5X the per-view earnings you'd get from YouTube instantly!
 
 Furthermore, you can share content of any type – video, music, ebooks, images, podcasts – all on the same platform.


### PR DESCRIPTION
When viewing this webpage online, this backslash is visible.

### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

When viewing https://lbry.com/faq/earn-income, the sixth paragraph displays a visible backslash before the dollar sign. Looking at the commits shows this backslash was added with purpose (586357a5c78d1fde74d3b7594deef2b79922a9af), though its appearance in the rendered site does seem off. Perhaps this is indicative of a different issue (bug?) that caused the backslash to appear, but I figured this PR may serve as a fix.

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #
I haven't made an issue, but I can to document these changes