### PR TITLE
Clarifying what kind of effect blocking has

### DIFF
--- a/content/faq/lbry-basics.md
+++ b/content/faq/lbry-basics.md
@@ -103,7 +103,7 @@ You can subscribe to a channel by clicking the Follow button from the homepage, 
 ![Manage tags](https://spee.ch/@lbryfaqsc:7/LBRY-manage-tags.jpg)
 
 ## How can I block channels?
-You can block a channel by clicking the **Block** button from the homepage, channel page, or content pages.
+You can block a channel by clicking the **Block** button from the homepage, channel page, or content pages. Blocking only prevents you from seeing content from the channel you block. Blocked channel can still access your content.
 
 ## Content consistently fails to stream or download. What should I do?
 Please see our [streaming guide](/faq/unable-to-stream) if you consistently cannot download or stream content on LBRY. If you are having intermittent issues with download failures, try closing LBRY Desktop completely (including ending the "lbrynet.exe" process in task manager) and re-initiating the download.


### PR DESCRIPTION
### Description

Clearly state that blocking channel only affects what content the one who blocked can see. 
I thought it would be good to have some black on white of how it works, as some think that blocking prevents owner of blocked channel from accessing to your channel.
(There was question about this in discord server, and info provided was bit mixed. I tested the blocking feature myself and it appeared to work as I've added to file.)

How I tested:
1. Created virtual machine running Ubuntu and download lbry AppImage
2. Launched lbry on virtual machine and send few LBCs to that wallet so channel could be created.
3. On lbry running on host machine, I blocked newly created channel. And waited like 15min just to be sure that if something happens it has some time to do that.
4. Back to virtual machine, Tried to search videos which are tied to wallet on host machine and was able to access content normally