### PR TITLE
Update benefit-consumers.md - "paid to seed" phrase misleading

### DIFF
--- a/content/faq/benefit-consumers.md
+++ b/content/faq/benefit-consumers.md
@@ -6,7 +6,7 @@ order: 2
 
 Do you watch YouTube? Imagine paying a few cents to eliminate all ads. 100% of the payment will go directly to the content creator – and they'll still be earning more than YouTube offers, so they'll want to make even more of the content you love.
 
-Do you use BitTorrent? Imagine getting paid to seed files into the network. Because there is a marketplace for these files, you can finally find rare songs and films that can't support a torrent swarm based on popularity alone.
+Do you use BitTorrent? Imagine getting [paid to seed](https://lbry.com/faq/host-content) files into the network. Because there is a marketplace for these files, you can finally find rare songs and films that can't support a torrent swarm based on popularity alone.
 
 Do you shop on the iTunes Store? Imagine paying less for songs, TV episodes, and music videos while having 100% of the cost go directly to the creators.
 


### PR DESCRIPTION
Make it more clear that _paid to seed_ feature is not implemented yet by linking the phrase to the [host-content](https://lbry.com/faq/host-content) page which has following bold warning in the bottom:

> Please note: Hosting fees are currently disabled on the network as we're currently working on a better way to implement the fee structure.

(was the big reason I was into LBRY, resulted in a big downer)

### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #