### PR TITLE
Clear confusion about `Download directory` vs blobfiles in lbry-directories.md

### DIFF
--- a/content/faq/lbry-directories.md
+++ b/content/faq/lbry-directories.md
@@ -35,3 +35,7 @@ Depending on which OS and wallet you use, LBRY files may be stored in several pl
  *Use file manager to navigate to the path below*
 - `Internal storage/android/data/io.lbry.browser/files/lbrynet` - Daemon configuration, logs, encrypted blob files
 - `Internal storage/android/data/io.lbry.browser/files/lbryum` - Wallet and blockchain data
+
+_____________________________
+
+Note: do not confuse blobfiles with `Download directory` that you define in app settings. The `Download directory` is just a path where all downloaded files are copied for your potential convenience, the files placed there are not used by LBRY anyhow. You can disable saving copies of all viewed content in _Advanced Settings_. If you want to change the location of actual `/blobfiles/` participating in LBRY network distribution, refer to [this instruction](https://lbry.com/faq/how-to-change-lbry-blob-files).


### PR DESCRIPTION
### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

See https://github.com/lbryio/lbry-desktop/issues/3891

Me, and I believe many other people mistakenly assumed the `Download directory` in the settings to be the place where seeded content is stored. There are some tickets of people getting surprised after getting notification about no space left on system disk despite them specifying this directory to be on a different volume.

After adding this note I hope it will become easier for people to understand what are the steps to seed properly and not worry about their system disk getting clogged.

Feedback and corrections to the message are also welcome.

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes https://github.com/lbryio/lbry-desktop/issues/3891