### PR TITLE
support: Fix visual glitch in unordered list

### DIFF
--- a/content/faq/support.md
+++ b/content/faq/support.md
@@ -18,7 +18,5 @@ If you're using LBRY Desktop, LBRY log files will help us better understand the 
 To report an issue, you can do one of the following:
 
 - Send us an email to [help@lbry.com](mailto:help@lbry.com) with the details of your issue or bug report. If it's troubleshooting related, please attach [your LBRY log file](/faq/how-to-find-lbry-log-file).
-
 - Go to the "Help" page of the app and then click the "Submit a Bug Report" button.
-
 - If you're a developer or otherwise technical and want to interact with LBRY developers directly, you're welcome to open an issue directly on GitHub. Please try to open network or protocol related issues [on our sdk channel in github](https://github.com/lbryio/lbry/issues) and interface, usability, and other application related issues [going to issues over your platform of choice](https://github.com/lbryio) (such as [desktop](https://github.com/lbryio/lbry-desktop/issues)). We would appreciate a quick search to see if similar issues already exist, as well.


### PR DESCRIPTION
Newlines between each list entry creates glitched unordered list in the web version.

### Description

Having newlines between each list entry makes a glitched unordered list (all browsers + mobile) on the webpage: https://lbry.com/faq/support

![bilde](https://user-images.githubusercontent.com/5418180/117533401-e986cb80-afec-11eb-85a1-7cb08135a2f0.png)

This document was last addressed in #1359 were proper links was added, but the glitched list remained (even when changed from numbered list). Having no newlines between entries are also in line with other documents using `-` for lists and displaying them correctly (even list entries spanning multiple lines)

I saw this when getting a message on Odysee: "This account must undergo review before you can participate in the rewards program". I'll pass the review, no worries 😄 