### PR TITLE
Block explorer link not available

### DIFF
--- a/content/faq/blockchain-explorer.md
+++ b/content/faq/blockchain-explorer.md
@@ -4,6 +4,3 @@ category: other
 ---
 
 Yep. You can see it at [https://explorer.lbry.com](https://explorer.lbry.com).
-
-If the enslaved squirrels that run our community block explorer are sleeping, try
-[https://lbrypool.com/explorer/LBC](https://lbryexplorer.tech/)


### PR DESCRIPTION
The block explorer link called, https://lbrypool.com/explorer/LBC, is not available. I have retired it, but if it is necessary to add other information, with pleasure.