### PR TITLE
Makes progress on removing Odysee references; makes other minor edits. 

### DIFF
--- a/content/faq/android-basics.md
+++ b/content/faq/android-basics.md
@@ -68,7 +68,7 @@ The LBRY wallet is different from other wallets - it also stores your shared con
 
 4. Enter a `Title` and `Description` for your content.
 
-5. Next, you can add tags to your content which will help categorize it for [discovery purposes](https://lbry.com/faq/trending). If it's intended for mature audiences, please add the pink `mature` tag. Next, determine any other tags that relate to the content you are publishing. Please be mindful of accuracy when tagging content as this is currently up to the publisher only and cannot be edited. If incorrect/inappropriate tags are used, your content may be filtered to provide a better user experience. In the future, this will be done through community voting and building a web of trust.
+5. Next, you can add `tags` to your content which will help categorize it for [discovery purposes](https://lbry.com/faq/trending). If it's intended for mature audiences, please add the pink `mature` tag. Next, determine any other tags that relate to the content you are publishing. Please be mindful of accuracy when tagging content as this is currently up to the publisher only and cannot be edited. If incorrect/inappropriate tags are used, your content may be filtered to provide a better user experience. In the future, this will be done through community voting and building a web of trust.
 
 ![publish process](https://thumbs.spee.ch/view/a/5085234b9874d903.jpg)
 

--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -10,9 +10,11 @@ To see our recommended video upload format and settings, please see our [video p
 
 If you are a YouTube Sync user, please make sure to [read our FAQ](https://lbry.com/faq/youtube) on how this process works.
 
-If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com).
+If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com). Please note that Odysee is a separate company. For specific help regarding Odysee, [refer to Odysee.com](https://odysee.com/$/help).
 
 **IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow-for-follow/view-for-view type activity is prohibited and will not be tolerated.**
+
+**OTHER NOTE: The following photos are still from the Odysee user interface. However, the differences between that and the LBRY Desktop interface are minimal.**
 
 ## How do I publish content?
 
@@ -28,7 +30,7 @@ If you don't have LBRY yet, download it [here](/get). You can also publish files
 
 6. On your local machine, select the content you wish to upload to LBRY. For video content, LBRY works best with MP4 files in H264/AAC format which support proper streaming (see [video publishing guide for details](/faq/video-publishing-guide)). Besides videos, other popular formats supported are MP3s, text documents like markdown (md)/HTML, PDF, CSV, and comic books (cbr, cbz). In the future, the in app player may support additional formats.
 
-Other file types can also be uploaded, but won't be streamable via Odysee directly. They can be opened externally for viewing on the Desktop/Android apps.
+Other file types can also be uploaded, but won't be streamable via Odysee directly. They can be opened externally for viewing on the LBRY Desktop/Android apps.
 
 7. Enter a `Description` for your content.
 

--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -12,9 +12,11 @@ If you are a YouTube Sync user, please make sure to [read our FAQ](https://lbry.
 
 If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com). Please note that Odysee is a separate company. For specific help regarding Odysee, [refer to Odysee.com](https://odysee.com/$/help).
 
-**IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow-for-follow/view-for-view type activity is prohibited and will not be tolerated.**
+The following photos are still from the Odysee user interface. However, the differences between that and the LBRY Desktop interface are minimal. 
 
-**OTHER NOTE: The following photos are still from the Odysee user interface. However, the differences between that and the LBRY Desktop interface are minimal.**
+[comment]: <> (The above line can be removed once we update the photos to be of the LBRY UI.)
+
+**IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow-for-follow/view-for-view type activity is prohibited and will not be tolerated.**
 
 ## How do I publish content?
 
@@ -37,13 +39,13 @@ Other file types can also be uploaded, but won't be streamable via Odysee direct
 8. Choose a `Thumbnail` or `Thumbnail URL` for your content. The `Thumbnail URL` is a hyperlink to an image file which will serve as a preview for your content. It can be any image/GIF URL. The default pixel size is 800x450, but the app will scale it up/down. Images uploaded directly from your local machine as `Thumbnail` will be uploaded to [spee.ch](https://www.spee.ch).
 
 9. Next you can add tags to your content which will help categorize it for [discovery purposes](https://lbry.com/faq/trending). If it's intended for mature audiences, please add the pink `mature` tag. Next, determine any other tags that relate to the content you are publishing. Please be mindful of accuracy when tagging content as this is currently up to the publisher only and cannot be edited. If incorrect/inappropriate tags are used, your content may be filtered to provide a better user experience. In the future, this will be done through community voting and building a web of trust.
-10. Right below the tags, you will be able to check disbale or enable viewers to leave a comment on your content.
+10. Right below the tags, you will be able to check, disable, or enable viewers to leave a comment on your content.
 
 11. Type in a minimum of 0.0001 LBC deposit for the upload (default amount is higher due to publishing fees). If you are trying to outbid a user-friendly/common URL, the system will suggest a minimum bid to take over the content at that vanity URL. There may be a delay for this takeover. Making your bid higher will result in [better discovery](https://lbry.com/faq/trending) for your content. For more details regarding the URL or bid, check out our [naming document](/faq/naming).
 
 12. You should have an option to set a price on on your content or make it free.
 
-13. Next, there is `Additional Option` which gives you an option to select language and license. Default language is set to `English`, and the License is set to `None`. If a change is needed, click the dropdown menus and select the appropriate choice.
+13. Next, there is `Additional Option` which gives you an option to select language and license. Default language is set to `English`, and the license is set to `None`. If a change is needed, click the dropdown menus and select the appropriate choice.
 
 _please review our terms of service before publishing [terms of service](/termsofservice)_
 

--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -12,7 +12,7 @@ If you are a YouTube Sync user, please make sure to [read our FAQ](https://lbry.
 
 If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com).
 
-**IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow for follow/view for view type activity is prohibited and will not be tolerated.**
+**IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow-for-follow/view-for-view type activity is prohibited and will not be tolerated.**
 
 ## How do I publish content?
 

--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -26,7 +26,7 @@ If you don't have LBRY yet, download it [here](/get). You can also publish files
 4. Next, type the title for your content. 
 5. After entering the title, click browse to browse the content you want to publish.
 
-6. On your local machine, select the content you wish to upload to Odysee. For video content, Odysee works best with MP4 files in H264/AAC format which support proper streaming (see [video publishing guide for details](/faq/video-publishing-guide)). Besides videos, other popular formats supported are MP3s, text documents like markdown (md)/HTML, PDF, CSV, and comic books (cbr, cbz). In the future, the in app player may support additional formats.
+6. On your local machine, select the content you wish to upload to LBRY. For video content, LBRY works best with MP4 files in H264/AAC format which support proper streaming (see [video publishing guide for details](/faq/video-publishing-guide)). Besides videos, other popular formats supported are MP3s, text documents like markdown (md)/HTML, PDF, CSV, and comic books (cbr, cbz). In the future, the in app player may support additional formats.
 
 Other file types can also be uploaded, but won't be streamable via Odysee directly. They can be opened externally for viewing on the Desktop/Android apps.
 

--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -10,60 +10,80 @@ To see our recommended video upload format and settings, please see our [video p
 
 If you are a YouTube Sync user, please make sure to [read our FAQ](https://lbry.com/faq/youtube) on how this process works.
 
-If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com). Please note that Odysee is a separate company. For specific help regarding Odysee, [refer to Odysee.com](https://odysee.com/$/help).
+If you don't have LBRY yet, download it [here](/get). You can also publish files up to 4 GB from the web at [Odysee.com](https://odysee.com). Please note that Odysee is a separate company. For specific instructions regarding publishing to the LBRY blockchain via Odysee, [refer to Odysee.com](https://odysee.com/$/help).
 
-The following photos are still from the Odysee user interface. However, the differences between that and the LBRY Desktop interface are minimal. 
-
-[comment]: <> (The above line can be removed once we update the photos to be of the LBRY UI.)
+For instructions on how to publish to Android, please check out our [publishing quickstart guide](/faq/publish-quickstart#android) or our more comprehensive [LBRY for Android basics](/faq/android-basics#publish).
 
 **IMPORTANT NOTE: Only use appropriate tags when publishing content. Tag abuse and follow-for-follow/view-for-view type activity is prohibited and will not be tolerated.**
 
 ## How do I publish content?
 
-1. Click on the Publish button next to the search bar to the right. You will get a dropdown, select `Upload` from the menu.
-   ![Click the Publish Button](https://spee.ch/f9de76e5b2b2052d:9.png)
+1. Click on the `Publish` button next to the search bar to the right. You will get a dropdown, select `Upload` from the menu.
+
+   ![Click the Publish Button](https://spee.ch/2/73d8c9c9e2267c62.png)
    
 2. Under the `Upload` section, you have the option to select/create the channel you would like to publish the content under. If no channel is selected, it will be posted anonymously.
-   ![Select Channel or Anonymous](https://spee.ch/3/3e792cfe222dd6ad.png)
+
+   ![Select Channel or Anonymous](https://spee.ch/6/2b648d023e2bd64c.png)
 
 3. Give your content a name which could be the same as your title but with no spaces. You can use `-` in place of the space. 
 4. Next, type the title for your content. 
-5. After entering the title, click browse to browse the content you want to publish.
+5. After entering the title, click `Browse` to browse the content you want to publish.
 
 6. On your local machine, select the content you wish to upload to LBRY. For video content, LBRY works best with MP4 files in H264/AAC format which support proper streaming (see [video publishing guide for details](/faq/video-publishing-guide)). Besides videos, other popular formats supported are MP3s, text documents like markdown (md)/HTML, PDF, CSV, and comic books (cbr, cbz). In the future, the in app player may support additional formats.
 
-Other file types can also be uploaded, but won't be streamable via Odysee directly. They can be opened externally for viewing on the LBRY Desktop/Android apps.
+Other file types can also be uploaded, but may not be streamable via third-party frontends (like Odysee). However, they can be opened via the LBRY Desktop/Android apps.
 
 7. Enter a `Description` for your content.
 
+   ![Write a content description](https://spee.ch/b/19415056ee007623.png)
+
 8. Choose a `Thumbnail` or `Thumbnail URL` for your content. The `Thumbnail URL` is a hyperlink to an image file which will serve as a preview for your content. It can be any image/GIF URL. The default pixel size is 800x450, but the app will scale it up/down. Images uploaded directly from your local machine as `Thumbnail` will be uploaded to [spee.ch](https://www.spee.ch).
 
-9. Next you can add tags to your content which will help categorize it for [discovery purposes](https://lbry.com/faq/trending). If it's intended for mature audiences, please add the pink `mature` tag. Next, determine any other tags that relate to the content you are publishing. Please be mindful of accuracy when tagging content as this is currently up to the publisher only and cannot be edited. If incorrect/inappropriate tags are used, your content may be filtered to provide a better user experience. In the future, this will be done through community voting and building a web of trust.
+9. Next you can add `Tags` to your content which will help categorize it for [discovery purposes](https://lbry.com/faq/trending). If it's intended for mature audiences, please add the pink `mature` tag. Next, determine any other tags that relate to the content you are publishing. Please be mindful of accuracy when tagging content as this is currently up to the publisher only and cannot be edited. If incorrect/inappropriate tags are used, your content may be filtered to provide a better user experience. In the future, this will be done through community voting and building a web of trust.
+
+   ![Add some tags](https://spee.ch/d/fbcd0d4f89caa300.png) 
+
 10. Right below the tags, you will be able to check, disable, or enable viewers to leave a comment on your content.
 
 11. Type in a minimum of 0.0001 LBC deposit for the upload (default amount is higher due to publishing fees). If you are trying to outbid a user-friendly/common URL, the system will suggest a minimum bid to take over the content at that vanity URL. There may be a delay for this takeover. Making your bid higher will result in [better discovery](https://lbry.com/faq/trending) for your content. For more details regarding the URL or bid, check out our [naming document](/faq/naming).
 
 12. You should have an option to set a price on on your content or make it free.
 
+   ![Set a price](https://spee.ch/f/8c23145c5e15dad5.png)
+
 13. Next, there is `Additional Option` which gives you an option to select language and license. Default language is set to `English`, and the license is set to `None`. If a change is needed, click the dropdown menus and select the appropriate choice.
 
-_please review our terms of service before publishing [terms of service](/termsofservice)_
+   ![Choose addtitional settings for content](https://spee.ch/3/c05592cc3d91e7a4.png)
 
-13. Click `Upload`.
+14. Please review our [terms of service](/termsofservice) before publishing.
 
-The file will process in the background and will be added to the LBRY Blockchain. Please leave LBRY/ Odysee.com open while your content is in the "pending confirmation" mode. This page will automatically refresh and you will be notified when the publish is completed. After this, your content will be available to other Odysee users. *It is a good idea to leave LBRY open for a while after this to make sure the app is able to share your file to at least one peer on the data network. Larger files will take longer to upload depending on your network speed.
+15. Click `Upload`
+
+16. Read the summary in the `Confirm Upload` box to make sure the data is accurate. If you want to change anything, then click `Cancel`, otherwise, if you are satisfied with what you see, click `Upload`.
+
+   ![Finish the upload process](https://spee.ch/d/231488c4ad3b01c1.png)
+
+The file will process in the background and will be added to the LBRY Blockchain. Please leave LBRY open while your content is in the "pending confirmation" mode. This page will automatically refresh and you will be notified when the publish is completed. After this, your content will be available to other LBRY users. 
+
+   ![File pending on LBRY](https://spee.ch/4/52c8df708a73e2b5.png)
+
+*It is a good idea to leave LBRY open for a while after this to make sure the app is able to share your file to at least one peer on the data network. Larger files will take longer to upload depending on your network speed.
 
 *You can continue to use LBRY while the upload completes.
 
 ## How do I create a channel?
 
-1. Open Odysee.com
+The following images show the user interface for Odysee.com. Never fear! The process and appearance is almost identical to LBRY Desktop (as of December 2021).
+
+1. Open the LBRY app.
 
 2. Click on the cloud with an arrow pointing into it in the top right next to the search bar. 
 
 3. Select `New Channel` in the dropdown menu.
 
 4. Fill in your your preffered channel name, title and description. Please ensure that you have enough LBRY Credits in your wallet to cover the bid amount. There is also a small network fee associated with the creation of a channel.
+
    ![Create Channel](https://spee.ch/6/30ecd0c691409d0f.png)
    
 5. Click `Submit` once you have entered your bid amount. You now own `lbry://@channelnameyoubidon` (the vanity name without a claim id) if you are the highest bidder.
@@ -71,12 +91,14 @@ The file will process in the background and will be added to the LBRY Blockchain
 ## How do I customize my channel? {#channel}
 
 First, you need to access your channel by clicking on the channel art or the astronaught icon on the upper right corner.
+
 ![Access Channel](https://spee.ch/8/e2874343f6eb54b6.png)
 
 1. You will now see an edit button next to the name. Click the button to proceed to the edit page.
+
    ![edit1](https://spee.ch/181f0fcbfafa5098:9.png)
 
-2. You can now upload your thumbnail and cover image by clicking the camera icon, select browse to choose the thumbnail or banner for your channel or use the option for url to add an image link. The page will update once a valid URL is available.
+2. You can now upload your thumbnail and cover image by clicking the `camera icon`, select `Browse` to choose the thumbnail or banner for your channel or use the option for url to add an image link. The page will update once a valid URL is available.
 
 ![edit2](https://spee.ch/e/ad430567d07974ac.png)
 
@@ -85,11 +107,12 @@ First, you need to access your channel by clicking on the channel art or the ast
 
 ## How do I delete my content and reclaim my deposit?
 
-1. Click on the channel /astronaut logo on the upper right corner and select Uploads
+1. Click on the `channel logo` on the upper right corner and select `Uploads`.
 
-2. This should display all uploads. Click on the content you want to remove from Odysee
+2. This should display all uploads. Click on the content you want to remove from LBRY.
 
 3. Click on the `Delete` icon.
+
 ![delete content](https://spee.ch/b/5eb8de5a8ce56488.png)
 
 4. There will be an option for `Abandon on blockchain (reclaim your LBC)`. Check if that applies. Abandoning your claim will release the LBC back into your wallet (99% of the time you want to select this).
@@ -100,7 +123,7 @@ First, you need to access your channel by clicking on the channel art or the ast
 
 ## How do I edit my existing published content?
 
-1. Click on the channel /astronaut logo on the upper right corner and select Uploads
+1. Click on the `channel logo` on the upper right corner and select `Uploads`.
 2. Select the content you want to update.
 3. Click `Edit`.
 4. You can now edit your claim information. No need to re-select the file if it's the same one or has the same url.
@@ -108,7 +131,7 @@ First, you need to access your channel by clicking on the channel art or the ast
 
 ## Where is my content stored and shared from? {#blobs}
 
-Content uploaded is chunked up into 2MB files called blobs, and stored in your [lbrynet/blob files folder](https://lbry.com/faq/lbry-directories). These can be deleted if the video is fully streamable on [https://odysee.com](https://odysee.com).
+Content uploaded is chunked up into 2MB files called blobs, and stored in your [lbrynet/blob files folder](/faq/lbry-directories). 
 
 ## Can someone tip me for my content?
 
@@ -118,13 +141,13 @@ Yes, check out how tipping in LBRY works by going [here](/faq/tipping).
 
 Yes, the claim can be edited to increase the bid amount or you can also send a Support to your own content. The Support button will appear instead of the tip button for your own claims. See the [FAQ](/faq/tipping) to learn more.
 
-## My video doesn't stream in the app or on odysee.com, what's wrong?
+## My video doesn't stream in the app; what's wrong?
 
-The in-app and odysee.com video player's streaming capability works best with the H264/AAC format, typically in an MP4 container but others like M4V will also work. Other non-streaming video types like AVI/WMV/MOV file formats are not supported by the in-app player, but they can be shared/downloaded and will play outside of the app.
+The in-app video player's streaming capability works best with the H264/AAC format, typically in an MP4 container but others like M4V will also work. Other non-streaming video types like AVI/WMV/MOV file formats are not supported by the in-app player, but they can be shared/downloaded and will play outside of the app.
 
 ## I shared my URL, but others can't download it. What's going on?
 
-Since LBRY is a Peer-to-Peer network, it requires that your device is accessible to the internet. LBRY also runs servers to assist in content hosting, but this process may fail if your device cannot send it to us or if you didn't wait long enough after the initial publish. Try quitting (Ctrl-Q) and restarting the LBRY app if the content is not accessible on [odysee.com](https://odysee.com).
+Since LBRY is a Peer-to-Peer network, it requires that your device is accessible to the Internet. LBRY also runs servers to assist in content hosting, but this process may fail if your device cannot send it to us or if you didn't wait long enough after the initial publish. Try quitting (Ctrl-Q) and restarting the LBRY app if the content is not accessible.
 
 ## Where is my channel and content saved locally?
 
@@ -132,7 +155,7 @@ Channels and content claims are saved to your LBRY Wallet along with your LBRY C
 
 ## How and where can I share my content?
 
-LBRY URLs can be shared with anyone - users can view it in their Desktop app or on [odysee.com](https://odysee.com) (see Share button in app). If the content is free and public, it can also be retrieved. You can also share the content on our on [Discord](https://chat.lbry.com) where we have a vibrant community with thousands of users.
+LBRY URLs can be shared with anyone - users can view it in their Desktop app or on a third-party frontend like [Odysee.com](https://odysee.com) (see Share button in app). If the content is free and public, it can also be retrieved. You can also share the content on our on [Discord](https://chat.lbry.com) where we have a vibrant community with thousands of users.
 
 ## I'm an advanced user, is there more I can poke around with?
 

--- a/content/faq/publish-quickstart.md
+++ b/content/faq/publish-quickstart.md
@@ -15,7 +15,7 @@ We'll start with publishing on LBRY Desktop and Odysee.com. Scroll down or [clic
 ![publish-menu](https://spee.ch/2/73d8c9c9e2267c62.png)  
 1. From top left dropdown menu, you can choose channel you want to use for current publish.
 1. Choose *Name* for your publish. (This will become part of the URL of your publish and can't be edited later, learn more from here: [Naming](/faq/naming))
-1. Set *Title* for your publish. (This is the title shown with thumbnaile, when browsing the website or apps, and it can be edited later.)
+1. Set *Title* for your publish. (This is the title shown with thumbnail, when browsing the website or apps, and it can be edited later.)
 1. Select the file you want to publish by clicking **Browse**. On desktop app you may have option to ![automatically transcode](/faq/video-publishing-guide#automatic) video for better streaming performance.
 ![choose-file&name](https://spee.ch/6/2b648d023e2bd64c.png)
 1. Fill in other details for the content you are uploading, including description, tags, thumbnail, possible price, etc. 


### PR DESCRIPTION
### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

Where available, I updated text and spee.ch photo links of “/faq/how-to-publish” to reflect the recent change in the legal relationship between LBRY and Odysee. However, more photos need to be added to spee.ch to show the channel creation/modification processes in the LBRY Desktop app. When that happens, the remaining photos will need to be appropriately replaced and the following paragraph removed: 
>“The following images show the user interface for Odysee.com. Never fear! The process and appearance is almost identical to LBRY Desktop (as of December 2021).” 

Fixed several spelling/grammar/formatting mistakes. 

Added some white space to improve readability. 

IMPORTANT NOTE: While this pull request works toward the goal of resolving this issue ([Remove Odysee references from FAQ #1472](https://github.com/lbryio/lbry.com/issues/1472#issue-1073761745)), it does not fully achieve it. That is why I am not listing that issue in the Fixes section below. 

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #