### PR TITLE
Updates Exchanges Documentation

### DIFF
--- a/content/faq/exchanges.md
+++ b/content/faq/exchanges.md
@@ -9,16 +9,12 @@ For a more in depth guide on buying/selling, see our [Bittrex FAQ](/faq/buy-sell
 
 ## Traditional crypto exchanges
 - [Bittrex - International Only, US Trading Disabled](https://bittrex.com/Market/Index?MarketName=BTC-LBC) ([USD](https://bittrex.com/Market/Index?MarketName=USD-LBC), [ETH](https://bittrex.com/Market/Index?MarketName=ETH-LBC), [USDT](https://bittrex.com/Market/Index?MarketName=USDT-LBC))
-- [MXC](https://www.mxc.la/trade/easy#LBC_USDT)
-- [BitMart](https://www.bitmart.com/trade/en?symbol=LBC_USDT&layout=basic) / [USDT](https://www.bitmart.com/trade/en?symbol=LBC_USDT&layout=basic)
+- [MEXC](https://www.mexc.com/exchange/LBC_USDT)
 - [Hotbit](https://www.hotbit.io/exchange?symbol=LBC_BTC) / [USDT](https://www.hotbit.io/exchange?symbol=LBC_USDT)
-- [CoinEx](https://www.coinex.com/exchange?currency=btc&dest=lbc) / [USDT](https://www.coinex.com/exchange?currency=usdt&dest=lbc)
+- [CoinEx - International Only, US Trading Disabled](https://www.coinex.com/exchange?currency=btc&dest=lbc) / [USDT](https://www.coinex.com/exchange?currency=usdt&dest=lbc)
 - [CoinSpot](https://www.coinspot.com.au/chart/lbc) 
 
 ## Decentralized exchanges (DEX)
 - [Bisq](https://bisq.network)
-- [BlockDX](https://blockdx.com/)
+- [BlockDX](https://blockdx.net/)
 - [AtomicDEX](https://atomicdex.io)
-
-## Cross-Chain Exchanges
-- [pNetwork](https://dapp.ptokens.io/swap?asset=lbc&from=lbc&to=bsc)


### PR DESCRIPTION
### Description

Adds that CoinEX no longer supports the US market, changes MXC to MEXC, removes BitMart and pNetwork. 